### PR TITLE
Change the order on the MySQL handlers

### DIFF
--- a/site-cookbooks/LAMP/files/default/lamp/roles/mysql/handlers/main.yml
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/mysql/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 
-- name: restart mysql
-  service: name={{ mysql }} state=restarted
-
 - name: reload systemd
   command: systemctl daemon-reload
+
+- name: restart mysql
+  service: name={{ mysql }} state=restarted

--- a/site-cookbooks/LAMP/files/default/lamp/roles/mysql/tasks/server.yml
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/mysql/tasks/server.yml
@@ -68,4 +68,4 @@
   when: ansible_os_family == 'RedHat' and ansible_distribution_major_version > '6'
   notify:
     - reload systemd
-    - restart mysql
+    - restart mariadb

--- a/site-cookbooks/LAMP/files/default/lamp/roles/mysql/tasks/server.yml
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/mysql/tasks/server.yml
@@ -68,4 +68,4 @@
   when: ansible_os_family == 'RedHat' and ansible_distribution_major_version > '6'
   notify:
     - reload systemd
-    - restart mariadb
+    - restart mysql


### PR DESCRIPTION
MySQL needs to be restarted after systemd has been reloaded in order for the open-files limit override to properly take effect, as per the Ansible documentation:
Notify handlers are always run in the same order they are defined, not in the order listed in the notify-statement.