### PR TITLE
Reload systemd now instead of waiting for the handler

### DIFF
--- a/site-cookbooks/LAMP/files/default/lamp/roles/mysql/handlers/main.yml
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/mysql/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 
-- name: restart mysql
-  service: name={{ mysql }} state=restarted
-
 - name: reload systemd
   command: systemctl daemon-reload
+
+- name: restart mysql
+  service: name={{ mysql }} state=restarted

--- a/site-cookbooks/LAMP/files/default/lamp/roles/mysql/tasks/server.yml
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/mysql/tasks/server.yml
@@ -68,4 +68,4 @@
   when: ansible_os_family == 'RedHat' and ansible_distribution_major_version > '6'
   notify:
     - reload systemd
-    - restart mysql
+    - restart mariadb

--- a/site-cookbooks/LAMP/files/default/lamp/roles/mysql/tasks/server.yml
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/mysql/tasks/server.yml
@@ -68,4 +68,4 @@
   when: ansible_os_family == 'RedHat' and ansible_distribution_major_version > '6'
   notify:
     - reload systemd
-    - restart mariadb
+    - restart mysql

--- a/site-cookbooks/LAMP/files/default/lamp/roles/mysql/tasks/server.yml
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/mysql/tasks/server.yml
@@ -67,5 +67,7 @@
   template: src=limits.conf.j2 dest=/etc/systemd/system/mariadb.service.d/limits.conf
   when: ansible_os_family == 'RedHat' and ansible_distribution_major_version > '6'
   notify:
-    - reload systemd
     - restart mysql
+
+- name: reload systemd now
+  command: systemctl daemon-reload


### PR DESCRIPTION
Added command module to reload systemd as soon as the open-file limit override gets put in place so it takes effect before mysql gets restarted