### PR TITLE
makes some changes to accomidate 16.04+ and debian 8+ detection

### DIFF
--- a/site-cookbooks/LAMP/files/default/lamp/nginx_deploy.yml
+++ b/site-cookbooks/LAMP/files/default/lamp/nginx_deploy.yml
@@ -45,7 +45,7 @@
 
   pre_tasks:
     - include_vars: group_vars/Ubuntu_14.yml
-      when: ansible_os_family == 'Debian' and (ansible_distribution_version == '14.04' or ansible_distribution_version == '8')
+      when: ansible_os_family == 'Debian' and (ansible_distribution_version >= '14.04' or ansible_distribution_version >= '8')
       tags: [ 'ius-repos', 'nginx', 'php-fpm', 'php5-fpm', 'mysql', 'holland' ]
 
   roles:

--- a/site-cookbooks/LAMP/files/default/lamp/roles/apache2/tasks/install.yml
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/apache2/tasks/install.yml
@@ -43,12 +43,12 @@
   command:  /usr/sbin/a2dismod {{ item }}
   with_items:
     - "mpm_*"
-  when: ansible_os_family == 'Debian' and (ansible_distribution_version == '14.04' or ansible_distribution_version == '8')
+  when: ansible_os_family == 'Debian' and (ansible_distribution_version >= '14.04' or ansible_distribution_version >= '8')
   ignore_errors: yes
 
 - name: create mutex dir
   file: path=/var/run/apache2/ssl_mutex mode=0755 state=directory owner={{apache_user}} group={{apache_user}}
-  when: ansible_os_family == 'Debian' and (ansible_distribution_version == '14.04' or ansible_distribution_version == '8')
+  when: ansible_os_family == 'Debian' and (ansible_distribution_version >= '14.04' or ansible_distribution_version >= '8')
   ignore_errors: yes
 
 - name: copy module configuration templates

--- a/site-cookbooks/LAMP/files/default/lamp/site.yml
+++ b/site-cookbooks/LAMP/files/default/lamp/site.yml
@@ -36,7 +36,7 @@
 
   pre_tasks:
     - include_vars: group_vars/Ubuntu_14.yml
-      when: ansible_os_family == 'Debian' and (ansible_distribution_version == '14.04' or ansible_distribution_version == '8')
+      when: ansible_os_family == 'Debian' and (ansible_distribution_version >= '14.04' or ansible_distribution_version >= '8')
       tags: [ 'ius-repos', 'apache2', 'php5', 'mysql', 'phpmyadmin', 'holland' ]
 
   roles:


### PR DESCRIPTION
Also seems to fix issue #7 . I can duplicate before this update, but not after. Not clear on why this update would change that behavior though, unless Ansible is detecting the version of current 8 as something else. Uname shows 3.16.7-ckt11-1+deb8u5 so maybe it's seeing 8.5 or something similar and applying the old logic.