### PR TITLE
add Lsyncd monitoring support

### DIFF
--- a/site-cookbooks/LAMP/files/default/lamp/roles/lsyncd/tasks/lsyncd.yml
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/lsyncd/tasks/lsyncd.yml
@@ -1,5 +1,8 @@
 ---
 
+- name: Include monitor.yml
+  include: monitor.yml
+
 - name: Install packages on Redhat base
   yum: pkg={{item}} state=installed
   with_items:

--- a/site-cookbooks/LAMP/files/default/lamp/roles/lsyncd/tasks/lsyncd.yml
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/lsyncd/tasks/lsyncd.yml
@@ -66,7 +66,7 @@
 - name: Create dummy servers file
   file: path=/etc/lsyncd-servers.conf state=touch
 
-- name: Crete dummy excludes file
+- name: Create dummy excludes file
   file: path=/etc/lsyncd-excludes.txt state=touch
 
 - name: Add more inotify watches to the kernel

--- a/site-cookbooks/LAMP/files/default/lamp/roles/lsyncd/tasks/lsyncd.yml
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/lsyncd/tasks/lsyncd.yml
@@ -1,8 +1,5 @@
 ---
 
-- name: Include monitor.yml
-  include: monitor.yml
-
 - name: Install packages on Redhat base
   yum: pkg={{item}} state=installed
   with_items:
@@ -80,3 +77,6 @@
 
 - name: remove lsyncd directory
   file: path=/root/lsyncd-2.1.5 state=absent
+
+- name: Include monitor.yml
+  include: monitor.yml

--- a/site-cookbooks/LAMP/files/default/lamp/roles/lsyncd/tasks/monitor.yml
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/lsyncd/tasks/monitor.yml
@@ -20,4 +20,4 @@
     owner: root
     group: root
   notify: restart rackspace-monitoring-agent
-when: p.stat.exists
+  when: p.stat.exists

--- a/site-cookbooks/LAMP/files/default/lamp/roles/lsyncd/tasks/monitor.yml
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/lsyncd/tasks/monitor.yml
@@ -1,0 +1,23 @@
+- name: Create RS monitoring plugin folder
+  file: dest=/usr/lib/rackspace-monitoring-agent/plugins state=directory
+
+- name: Check /etc/rackspace-monitoring-agent.conf.d/
+  file: dest=/etc/rackspace-monitoring-agent.conf.d/ state=directory owner=root group=root
+
+- stat: path=/usr/bin/rackspace-monitoring-agent
+  register: p
+
+- name: Copy lsyncd_monitor.yaml
+  template: src=lsyncd_monitor.yaml.j2 dest=/etc/rackspace-monitoring-agent.conf.d/lsyncd_monitor.yaml
+  notify: restart rackspace-monitoring-agent
+  when: p.stat.exists
+
+- name: Download lsyncd-status.sh
+  get_url:
+    url: https://raw.githubusercontent.com/racker/rackspace-monitoring-agent-plugins-contrib/master/lsyncd-status.sh
+    dest: /usr/lib/rackspace-monitoring-agent/plugins/lsyncd-status.sh
+    mode: 0755
+    owner: root
+    group: root
+  notify: restart rackspace-monitoring-agent
+when: p.stat.exists

--- a/site-cookbooks/LAMP/files/default/lamp/roles/lsyncd/templates/lsyncd_monitor.yaml.j2
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/lsyncd/templates/lsyncd_monitor.yaml.j2
@@ -1,0 +1,22 @@
+type        : agent.plugin
+label       : '[AGENT] Lsyncd'
+disabled    : true
+period      : 60
+timeout     : 30
+details     :
+    file    : lsyncd-status.sh
+alarms      :
+    alarm1  :
+        label                 : '[AGENT] Lsyncd'
+        notification_plan_id  : {{notification_plan}} 
+        criteria              : |
+          if (metric['lsyncd_status'] != 'running') {
+            return new AlarmStatus(CRITICAL, 'Lsyncd Service is NOT running.');
+          }   
+          if (metric['lsyncd_status'] == 'running' && metric['percent_used_watches'] >= 80) {
+            return new AlarmStatus(WARNING, 'Lsyncd is running but the number of directories has reached 80% of notify watches.');
+          }
+          if (metric['lsyncd_status'] == 'running' && metric['percent_used_watches'] >= 95) {
+            return new AlarmStatus(CRITICAL, 'Lsyncd is running but the number of directories has reached 95% of notify watches.');
+          }
+            return new AlarmStatus(OK, 'Lsyncd Service is running.');


### PR DESCRIPTION
Adds monitoring support for the lsyncd playbook.  The monitor is created in a disabled state since lsyncd requires a few more configuration steps prior to being started.  The monitor can then be enabled in the control panel.